### PR TITLE
feat(RBAC): allow password policy get by api key

### DIFF
--- a/src/api/src/generic.rs
+++ b/src/api/src/generic.rs
@@ -270,7 +270,7 @@ pub async fn post_password_hash_times(
 /// Returns the currently configured password policy
 ///
 /// **Permissions**
-/// - authenticated
+/// - authenticated or ApiKey with `Generic::Read`
 #[utoipa::path(
     get,
     path = "/password_policy",
@@ -278,11 +278,12 @@ pub async fn post_password_hash_times(
     responses(
         (status = 200, description = "Ok", body = PasswordPolicyResponse),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
     ),
 )]
 #[get("/password_policy")]
 pub async fn get_password_policy(principal: ReqPrincipal) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_session_auth()?;
+    principal.validate_api_key_or_session_auth(AccessGroup::Generic, AccessRights::Read)?;
     let rules = PasswordPolicy::find().await?;
     Ok(HttpResponse::Ok().json(PasswordPolicyResponse::from(rules)))
 }

--- a/src/data/src/entity/principal.rs
+++ b/src/data/src/entity/principal.rs
@@ -166,6 +166,29 @@ impl Principal {
         }
     }
 
+    /// Validates an ApiKey OR a valid authenticated session.
+    /// If both are given, the ApiKey will have the higher priority since it is more specific.
+    /// Returns an error with an invalid ApiKey even when a valid session exists.
+    #[inline(always)]
+    pub fn validate_api_key_or_session_auth(
+        &self,
+        access_group: AccessGroup,
+        access_rights: AccessRights,
+    ) -> Result<(), ErrorResponse> {
+        match self.validate_api_key(access_group, access_rights) {
+            Ok(_) => Ok(()),
+
+            Err(err) => {
+                if err.error == ErrorResponseType::Forbidden {
+                    Err(err)
+                } else {
+                    self.validate_session_auth()?;
+                    Ok(())
+                }
+            }
+        }
+    }
+
     /// Validates the principal, that it is either an admin or the user matches the
     /// given `user_id`
     #[inline(always)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password policy endpoint now supports authentication via API key with Generic::Read access, in addition to session-based authentication.

* **Documentation**
  * Updated API documentation to reflect new authentication options and 403 Forbidden response for the password policy endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->